### PR TITLE
Fix code scanning alert no. 35: Reflected cross-site scripting

### DIFF
--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -14,6 +14,7 @@
 
 import * as express from 'express';
 import { Response } from 'express-serve-static-core';
+import escapeHtml from 'escape-html';
 import * as fs from 'fs';
 import * as _path from 'path';
 import { ApiExperiment, ApiListExperimentsResponse } from '../src/apis/experiment';
@@ -363,7 +364,7 @@ export default (app: express.Application) => {
         job.enabled = true;
         res.json({});
       } else {
-        res.status(500).send('Cannot find a job with id ' + req.params.jid);
+        res.status(500).send('Cannot find a job with id ' + escapeHtml(req.params.jid));
       }
     }, 1000);
   });
@@ -375,7 +376,7 @@ export default (app: express.Application) => {
         job.enabled = false;
         res.json({});
       } else {
-        res.status(500).send('Cannot find a job with id ' + req.params.jid);
+        res.status(500).send('Cannot find a job with id ' + escapeHtml(req.params.jid));
       }
     }, 1000);
   });

--- a/frontend/mock-backend/package.json
+++ b/frontend/mock-backend/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/express": "^4.16.0",
-    "express": "^4.16.3"
+    "express": "^4.16.3",
+    "escape-html": "^1.0.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/burrito-party/kubeflow-pipelines/security/code-scanning/35](https://github.com/burrito-party/kubeflow-pipelines/security/code-scanning/35)

To fix the problem, we need to sanitize the user input before incorporating it into the response. The best way to do this is to use a library that provides HTML escaping functionality. This will ensure that any potentially malicious characters in the user input are properly escaped, preventing the execution of injected scripts.

We will use the `escape-html` library to sanitize the `req.params.jid` before including it in the response message. This change will be made in the file `frontend/mock-backend/mock-api-middleware.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
